### PR TITLE
lisav2: remove hardcoded root user for functional test cases

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2725,6 +2725,7 @@ function Convert-StringToUInt64{
 
 function Check-Result{
 	param(
+		[String] $User,
 		[String] $vmPassword,
 		[String] $vmPort,
 		[String] $ipv4
@@ -2739,7 +2740,7 @@ function Check-Result{
 
 	while ($timeout -ne 0 )
 	{
-		Write-Output "yes" | .\tools\pscp.exe  -v -2 -unsafe -pw $vmPassword -q -P ${vmPort} root@${ipv4}:${stateFile} ${localStateFile} #| out-null
+		Write-Output "yes" | .\tools\pscp.exe  -v -2 -unsafe -pw $vmPassword -q -P ${vmPort}  ${User}@${ipv4}:${stateFile} ${localStateFile} #| out-null
 		$sts = $?
 		if ($sts)
 		{

--- a/Testscripts/Windows/BVT-VERIFY-KVP-DAEMON-STATUS.ps1
+++ b/Testscripts/Windows/BVT-VERIFY-KVP-DAEMON-STATUS.ps1
@@ -13,7 +13,7 @@ function Main {
         Write-LogInfo "Executing : $($currentTestData.testScriptPs1)"
         Set-Content -Value "**************$($currentTestData.testName)******************" -Path "$logDir\$($currentTestData.testName)_Log.txt"
         Write-LogInfo "Verifcation of KVP Daemon status is started.."
-        $kvpStatus = Run-LinuxCmd -username "root" -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "pgrep -lf 'hypervkvpd|hv_kvp_daemon'"
+        $kvpStatus = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "pgrep -lf 'hypervkvpd|hv_kvp_daemon'" -RunAsSudo
         Add-Content -Value "KVP Daemon Status : $kvpStatus " -Path "$logDir\$($currentTestData.testName)_Log.txt"
         if ($kvpStatus -imatch "kvp") {
             Write-LogInfo "KVP daemon is present in remote VM and KVP DAEMON STATUS : $kvpStatus"

--- a/Testscripts/Windows/DM-HOTADD-STRESS-APP.ps1
+++ b/Testscripts/Windows/DM-HOTADD-STRESS-APP.ps1
@@ -25,7 +25,7 @@ $scriptBlock = {
         $cmdToVM = @"
 #!/bin/bash
         if [ ! -e /proc/meminfo ]; then
-            echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
+            echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /home/$user/HotAdd.log 2>&1
             exit 100
         fi
         rm ~/HotAddErrors.log -f

--- a/Testscripts/Windows/FCOPY-LARGE-FILE.ps1
+++ b/Testscripts/Windows/FCOPY-LARGE-FILE.ps1
@@ -114,10 +114,10 @@ if ($createfile -notlike "File *testfile-*.file is created") {
 	return "FAIL"
 }
 # Verifying if /mnt folder on guest exists; if not, it will be created
-.\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "[ -d /mnt ]"
+Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -command "[ -d /mnt ]" -runAsSudo
 if (-not $?){
     Write-LogInfo "Folder /mnt not present on guest. It will be created"
-    .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "mkdir /mnt"
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -command "mkdir /mnt" -runAsSudo
 }
 
 $sts = Mount-Disk -vmPassword $VMPassword -vmPort $VMPort -ipv4 $Ipv4

--- a/Testscripts/Windows/FCOPY-NEGATIVE.ps1
+++ b/Testscripts/Windows/FCOPY-NEGATIVE.ps1
@@ -124,7 +124,7 @@ function Main {
     Write-LogInfo "Info: Step 1: fcopy file to vm when target folder is immutable"
 
     # Verifying if /tmp folder on guest exists; if not, it will be created
-    .\Tools\plink.exe -C -pw $VMPassword -P $VMPort root@$ipv4 "[ -d /test ] || mkdir /test ; chattr +i /test"
+    .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$ipv4 "sudo [ -d /test ] || mkdir /test ; chattr +i /test"
 
     if (-not $?) {
         Write-LogErr "Fail to change the permission for /test"
@@ -190,11 +190,11 @@ function Main {
         }
 
         # Verify the file does not exist after hypervfcopyd start
-        $daemonName = .\Tools\plink.exe -C -pw $vmPassword -P $vmPort root@$Ipv4 "systemctl list-unit-files | grep fcopy"
+        $daemonName = .\Tools\plink.exe -C -pw $vmPassword -P $vmPort $VMUserName@$Ipv4 "sudo systemctl list-unit-files | grep fcopy"
         $daemonName = $daemonName.Split(".")[0]
-        .\Tools\plink.exe -C -pw $VMPassword -P $VMPort root@$Ipv4 "systemctl start $daemonName"
+        .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "sudo systemctl start $daemonName"
         Start-Sleep -s 2
-        .\Tools\plink.exe -C -pw $vmPassword -P $vmPort root@$Ipv4 "ls /tmp/testfile-*"
+        .\Tools\plink.exe -C -pw $vmPassword -P $vmPort $VMUserName@$Ipv4 "sudo ls /tmp/testfile-*"
         if ($? -eq $true) {
             Write-LogErr "File has been copied to guest vm after restart hypervfcopyd"
             return "FAIL"

--- a/Testscripts/Windows/FCOPY-REPEATED-DELETE.ps1
+++ b/Testscripts/Windows/FCOPY-REPEATED-DELETE.ps1
@@ -102,7 +102,7 @@ else {
 }
 
 # Verifying if /tmp folder on guest exists; if not, it will be created
-.\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "[ -d /tmp ]"
+Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -command "[ -d /tmp ]" -runAsSudo
 if (-not $?){
     Write-LogInfo "Folder /tmp not present on guest. It will be created"
     .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "mkdir /tmp"

--- a/Testscripts/Windows/Heartbeat-PausedCritical.ps1
+++ b/Testscripts/Windows/Heartbeat-PausedCritical.ps1
@@ -197,7 +197,7 @@ function Main {
     Write-LogInfo "Info: Writing data on the VM disk in order to hit the disk limit"
 
     # Get the used space reported by the VM on the root partition
-    $usedSpaceVM = Run-LinuxCmd -username "root"-password $VMPassword -ip $ipv4vm1 -port $VMPort -command "df -B1 /root |  awk '{print `$3}' | tail -1"
+    $usedSpaceVM = Run-LinuxCmd -username  $VMUserName -password $VMPassword -ip $ipv4vm1 -port $VMPort -command "df -B1 /home/${VMUserName} |  awk '{print `$3}' | tail -1" -RunAsSudo
     Write-LogInfo "Used space: $usedSpaceVM"
 
     # Divide by 1 to convert string to double
@@ -215,7 +215,7 @@ function Main {
     }
 
     Write-LogInfo "Info: Filling $VMName with $ddFileSize MB of data."
-    Run-LinuxCmd -username "root" -password $VMPassword -ip $ipv4vm1 -port $VMPort -command "nohup dd if=/dev/urandom of=/root/data2 bs=1M count=$ddFileSize" -RunInBackGround
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $ipv4vm1 -port $VMPort -command "nohup dd if=/dev/urandom of=/home/${VMUserName}/data2 bs=1M count=$ddFileSize" -RunInBackGround -RunAsSudo
     Start-Sleep 90
 
     $vm1 = Get-VM -Name $VMName1 -ComputerName $HvServer

--- a/Testscripts/Windows/KDUMP-TestScript.ps1
+++ b/Testscripts/Windows/KDUMP-TestScript.ps1
@@ -129,8 +129,8 @@ function Main {
                 -command "taskset -c 2 echo c > /proc/sysrq-trigger"
         } else {
             # If directly use plink to trigger kdump, command fails to exit, so use start-process
-            Run-LinuxCmd -username "root" -password $VMPassword -ip $Ipv4 -port $VMPort `
-                -command "echo c > /proc/sysrq-trigger" -RunInBackGround
+            Run-LinuxCmd -username  $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+                -command "echo c > /proc/sysrq-trigger" -RunInBackGround -runAsSudo
         }
     }
 
@@ -161,7 +161,7 @@ function Main {
         }
         return "FAIL"
     }
-    $result = Run-LinuxCmd -username "root" -password $VMPassword -ip $Ipv4 -port $VMPort `
+    $result = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
                 -command "find /var/crash/ -name vmcore -type f -size +10M" -runAsSudo
     Write-LogInfo "Files found: $result"
     Write-LogInfo "Test passed: crash file $result is present"

--- a/Testscripts/Windows/KVP-MaxRead.ps1
+++ b/Testscripts/Windows/KVP-MaxRead.ps1
@@ -16,7 +16,7 @@ function Add-KVPEntries {
     #!/bin/bash
     ps aux | grep "[k]vp"
     if [ `$? -ne 0 ]; then
-      echo "KVP is disabled" >> /root/KVP.log 2>&1
+      echo "KVP is disabled" >> /home/$user/KVP.log 2>&1
       exit 1
     fi
 
@@ -33,7 +33,7 @@ function Add-KVPEntries {
             echo "32 bit architecture was detected"
             kvp_client="kvp_client32"
         else
-            echo "Error: Unable to detect OS architecture" >> /root/KVP.log 2>&1
+            echo "Error: Unable to detect OS architecture" >> /home/$user/KVP.log 2>&1
             exit 60
         fi
     fi
@@ -47,13 +47,13 @@ function Add-KVPEntries {
     done
 
     if [ `$? -ne 0 ]; then
-        echo "Failed to append new entries" >> /root/KVP.log 2>&1
+        echo "Failed to append new entries" >> /home/$user/KVP.log 2>&1
         exit 100
     fi
 
     ps aux | grep "[k]vp"
     if [ `$? -ne 0 ]; then
-        echo "KVP daemon failed after append" >> /root/KVP.log 2>&1
+        echo "KVP daemon failed after append" >> /home/$user/KVP.log 2>&1
         exit 100
     fi
 

--- a/Testscripts/Windows/KVP-PushKeyValues.ps1
+++ b/Testscripts/Windows/KVP-PushKeyValues.ps1
@@ -89,11 +89,11 @@ function Main {
     # image, then run kvp_client to add a non-intrinsic kvp item
     Write-LogInfo "Info: Trying to detect OS architecture"
     $kvpClient = $null
-    $retVal = Run-LinuxCmd -username "root" -password $VMPassword -ip $Ipv4 -port $VMPort `
-                -command "uname -a | grep x86_64"
+    $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+                -command "uname -a | grep x86_64" -runAsSudo
     if (-not $retVal) {
-        $retVal = Run-LinuxCmd -username "root" -password $VMPassword -ip $Ipv4 -port $VMPort `
-                    -command "uname -a | grep i686"
+        $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+                    -command "uname -a | grep i686" -runAsSudo
         if (-not ($retVal)) {
             Write-LogErr "Error: Could not determine OS architecture"
             return "FAIL"

--- a/Testscripts/Windows/Max-vCPU.ps1
+++ b/Testscripts/Windows/Max-vCPU.ps1
@@ -36,8 +36,8 @@ function Main {
             $guestMaxCPUs = 4
         } else {
             # Check VM OS architecture and set max CPU allowed
-            $linuxArch = Run-LinuxCmd -username "root" -password $VMPassword -ip `
-                            $Ipv4 -port $VMPort -command "uname -m"
+            $linuxArch = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip `
+                            $Ipv4 -port $VMPort -command "uname -m" -RunAsSudo
             if ($linuxArch -eq "i686") {
                 $guestMaxCPUs = 32
             }
@@ -95,8 +95,8 @@ function Main {
     }
 
     # Determine how many cores the VM has detected
-    $vCPU = Run-LinuxCmd -username "root" -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "cat /proc/cpuinfo | grep processor | wc -l"
+    $vCPU = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+            -command "cat /proc/cpuinfo | grep processor | wc -l" -RunAsSudo
     if ($vCPU -eq $guestMaxCPUs) {
         Write-LogInfo "CPU count inside VM is $guestMaxCPUs"
         Write-LogInfo "VM $VMName successfully started with $guestMaxCPUs cores."

--- a/Testscripts/Windows/SQM-Basic.ps1
+++ b/Testscripts/Windows/SQM-Basic.ps1
@@ -25,19 +25,19 @@ function Stop-KVP {
 #!/bin/bash
     ps aux | grep kvp
     if [ `$? -ne 0 ]; then
-      echo "KVP is already disabled" >> /root/StopKVP.log 2>&1
+      echo "KVP is already disabled" >> /home/$VMUser/StopKVP.log 2>&1
       exit 0
     fi
 
     kvpPID=`$(ps aux | grep kvp | awk 'NR==1{print `$2}')
     if [ `$? -ne 0 ]; then
-        echo "Could not get PID of KVP" >> /root/StopKVP.log 2>&1
+        echo "Could not get PID of KVP" >> /home/$VMUser/StopKVP.log 2>&1
         exit 0
     fi
 
     kill `$kvpPID
     if [ `$? -ne 0 ]; then
-        echo "Could not stop KVP process" >> /root/StopKVP.log 2>&1
+        echo "Could not stop KVP process" >> /home/$VMUser/StopKVP.log 2>&1
         exit 0
     fi
 
@@ -55,10 +55,10 @@ function Stop-KVP {
 
     # send file
     Copy-RemoteFiles -uploadTo $VMIpv4 -port $VMSSHPort -files $FILE_NAME `
-        -username "root" -password $VMPassword -upload
+        -username $VMUser -password $VMPassword -upload
 
-    $retVal = Run-LinuxCmd -username "root" -password $VMPassword -ip $VMIpv4 -port $VMSSHPort `
-        -command "cd /root && chmod u+x ${FILE_NAME} && sed -i 's/\r//g' ${FILE_NAME} && ./${FILE_NAME}"
+    $retVal = Run-LinuxCmd -username $VMUser -password $VMPassword -ip $VMIpv4 -port $VMSSHPort `
+        -command "cd /home/$VMUser/ && chmod u+x ${FILE_NAME} && sed -i 's/\r//g' ${FILE_NAME} && ./${FILE_NAME}" -RunAsSudo
 
     return $retVal
 }

--- a/Testscripts/Windows/STORAGE-HotUnplug.ps1
+++ b/Testscripts/Windows/STORAGE-HotUnplug.ps1
@@ -74,7 +74,6 @@ function Main {
 
     $scsi=$true
     $REMOTE_SCRIPT="STORAGE-HotRemove.sh"
-    $rootUser="root"
 
     if ($null -eq $testParams -or $testParams.Length -lt 3) {
         Write-LogErr "setupScript requires test params"
@@ -140,7 +139,7 @@ function Main {
 
         #verify if vm sees that disks were dettached
         $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "bash ~/${REMOTE_SCRIPT}"
+            -command "bash ~/${REMOTE_SCRIPT}" -RunAsSudo
 
         #Attaching the 1st VHDx again
         $retVal = Add-VHDxDiskDrive $vmName $hvServer $path1 $controllerType $controllerID1 $lun1
@@ -151,8 +150,8 @@ function Main {
         Write-LogErr "Attached first VHDx with path $path1"
         #wait for vm to see the disks
         Start-Sleep 5
-        $diskNumber = Run-LinuxCmd -username $rootUser -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "fdisk -l | grep 'Disk /dev/sd*' | grep -v 'Disk /dev/sda' | wc -l"
+        $diskNumber = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+            -command "fdisk -l | grep 'Disk /dev/sd*' | grep -v 'Disk /dev/sda' | wc -l" -RunAsSudo
         if ( $diskNumber -ne 2) {
             Write-LogErr "Failed to attach VHDx "
             return "FAIL"

--- a/Testscripts/Windows/STRESS-MTU-Netvsc-Reload.ps1
+++ b/Testscripts/Windows/STRESS-MTU-Netvsc-Reload.ps1
@@ -31,16 +31,14 @@ function Main {
         $RootDir
     )
 
-    $rootUser = "root"
-
     # Start changing MTU on VM
     $mtu_values = 1505, 2048, 4096, 8192, 16384
     $iteration = 1
     foreach ($i in $mtu_values) {
         Write-LogInfo "Changing MTU on VM to $i"
 
-        $null = Run-LinuxCmd -username $rootUser -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "sleep 5 && ip link set dev eth0 mtu $i"
+        $null = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+            -command "sleep 5 && ip link set dev eth0 mtu $i" -RunAsSudo
 
         Start-Sleep -s 30
         Test-Connection -ComputerName $ipv4
@@ -59,10 +57,10 @@ function Main {
     }
 
     Add-Content $scriptPath "$RELOAD_COMMAND"
-    Copy-RemoteFiles -uploadTo $Ipv4 -port $VMPort -password $VMPassword -username $rootUser `
+    Copy-RemoteFiles -uploadTo $Ipv4 -port $VMPort -password $VMPassword -username $VMUserName `
         -files $scriptPath -upload
-    $null = Run-LinuxCmd -username $rootUser -password $VMPassword -ip $Ipv4 -port $VMPort `
-        -command "dos2unix reload_netvsc.sh && sleep 5 && bash ~/reload_netvsc.sh" -RunInBackGround
+    $null = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+        -command "dos2unix reload_netvsc.sh && sleep 5 && bash ~/reload_netvsc.sh" -RunInBackGround  -RunAsSudo
 
     Start-Sleep -s 600
     Get-IPv4AndWaitForSSHStart -VmName $VMName -HvServer $HvServer -Vmport $VMPort `

--- a/Testscripts/Windows/Timesync-VDSO.ps1
+++ b/Testscripts/Windows/Timesync-VDSO.ps1
@@ -50,8 +50,8 @@ function Main {
 
     # Get time
     $timeCmd = "time -p (/home/${VMUserName}/gettime) 2>&1 1>/dev/null"
-    $result = Run-LinuxCmd -ip $Ipv4 -port $VMPort -username "root" -password `
-             $VMPassword -command $timeCmd
+    $result = Run-LinuxCmd -ip $Ipv4 -port $VMPort -username $VMUserName -password `
+             $VMPassword -command $timeCmd -runAsSudo
     $result = $result.Trim()
     Write-LogInfo $result
     #real 3.14 user 3.14 sys 0.00


### PR DESCRIPTION
**Hyper-V/ Ubuntu :**

[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 20:35:16
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 4 (4 Pass, 0 Fail, 0 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:28
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 FCOPY-LARGE-FILE                                                   PASS                11.15 
[hyperv]     2 FCOPY-REPEATED-DELETE                                              PASS                 4.93 
[hyperv]     3 FCOPY-DISABLE-ENABLE                                               PASS                 9.38 
[hyperv]     4 FCOPY-NEGATIVE                                                     PASS                 3.38 

[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 15:00:59
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 6 (6 Pass, 0 Fail, 0 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:45
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 KDUMP-CRASH-SINGLE-CORE                                            PASS                 8.82 
[hyperv]     2 KDUMP-CRASH-SMP                                                    PASS                 7.02 
[hyperv]     3 KDUMP-CRASH-NMI                                                    PASS                 7.87 
[hyperv]     4 KDUMP-CRASH-AUTO-SIZE                                              PASS                 6.66 
[hyperv]     5 KDUMP-CRASH-DIFFERENT-VCPU                                         PASS                 6.61 
[hyperv]     6 KDUMP-CRASH-16-CORES                                               PASS                 8.05 


[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 15:23:03
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 5 (4 Pass, 0 Fail, 1 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:47
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 SQM-BASIC                                                          PASS                 2.72 
[hyperv]     2 STORAGE-VHDX-HOT-PLUG-UNPLUG-SCSI                                  PASS                 4.89 
[hyperv]     3 MAX-VCPU                                                           PASS                 6.72 
[hyperv]     4 TIMESYNC-VDSO                                                   Aborted                 2.52 
[hyperv]     5 STRESSTEST-CHANGE-MTU-RELOAD-NETVSC                                PASS                30.79 
[hyperv] TIMESYNC-VDSO :[INFO ] Info: Current VM Linux kernel version does not support vDSO feature.

[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 15:47:11
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 2 (2 Pass, 0 Fail, 0 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:26
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 DYNAMIC-MEMORY-HOTADD-STRESS-APP                                   PASS                10.36 
[hyperv]     2 PAUSED-CRITICAL-HEARTBEAT                                          PASS                15.81 
[hyperv] 


[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 16:34:21
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 2 (1 Pass, 0 Fail, 1 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:5
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 KVP-PUSH-KEY-VALUES                                                PASS                 2.71 
[hyperv]     2 KVP-MAX-READ                                                    Aborted                 2.43 
[hyperv] 
[hyperv] 2 KVP-MAX-READ :
[hyperv] 12/13/2018 16:39:12 : [INFO ] Kernels older than 3.10.0-862 require LIS-4.x drivers.
[hyperv] 12/13/2018 16:39:12 : [ERROR] Error: No LIS-4.x drivers detected. Skipping test.



[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 16:05:52
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:0:14
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 BVT-CORE-RELOAD-MODULES-SMP                                        PASS                14.97 


[hyperv] [LISAv2 Test Results Summary]
[hyperv] Test Run On           : 12/13/2018 16:24:18
[hyperv] VHD Under Test        : ubuntu_18.04.1.vhdx
[hyperv] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[hyperv] Total Time (dd:hh:mm) : 0:1:45
[hyperv] XML File              : TestConfiguration
[hyperv] 
[hyperv]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[hyperv] ------------------------------------------------------------------------------------------------------
[hyperv]     1 STRESSTEST-RELOAD-MODULES-UP                                       PASS               105.42 


**Azure /Ubuntu :**


[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 12/13/2018 16:18:20
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 BVT-VERIFY-KVP-DAEMON-STATUS                                       PASS                 3.22 
[azure] 

[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 12/13/2018 16:27:28
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 5 (5 Pass, 0 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:0:29
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 KDUMP-CRASH-SINGLE-CORE                                            PASS                 5.83 
[azure]     2 KDUMP-CRASH-SMP                                                    PASS                 6.09 
[azure]     3 KDUMP-CRASH-AUTO-SIZE                                              PASS                 5.88 
[azure]     4 KDUMP-CRASH-DIFFERENT-VCPU                                         PASS                 5.58 
[azure]     5 KDUMP-CRASH-16-CORES                                               PASS                 5.88 

[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 12/13/2018 16:42:37
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:0:14
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 BVT-CORE-RELOAD-MODULES-SMP                                        PASS                14.45 
[azure] 
[azure] 


[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 12/13/2018 17:08:31
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:1:45
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 STRESSTEST-RELOAD-MODULES-UP                                       PASS               105.69 
[azure] 
[azure] 